### PR TITLE
Adding --fid optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Script options:
   -l, --lat-lims=REAL,REAL		Latitude's upper and lower bounds; optional
   -n, --lon-lims=REAL,REAL		Longitude's upper and lower bounds; optional
   -f, --shape-file=PATH			Path to the ESRI '.shp' file; optional
+  -F, --fid=STR				Column name representing elements of the
+  					ESRI Shapefile to report statistics; optional
+					defaults to the first column
   -j, --submit-job			Submit the data extraction process as a job
 					on the SLURM system; optional
   -t, --print-geotiff=BOOL		Extract the subsetted GeoTIFF file; optional

--- a/assets/stats.R
+++ b/assets/stats.R
@@ -33,6 +33,7 @@ output_path <- args[14];
 stats <- args[15];
 include_na <- args[16];
 quantiles <- args[17];
+fid <- args[18];
 
 # set the working directory path
 setwd(working_dir_path)
@@ -78,7 +79,11 @@ if (coord_var %in% s) {
 }
 
 # extract ID column name
-id_col <- names(p[1])[1]
+if (missing(fid)) {
+  id_col <- names(p[1])[1]
+} else {
+  id_col <- fid
+}
 
 # check `na_values`
 if (include_na == 'true') {

--- a/assets/stats.R
+++ b/assets/stats.R
@@ -79,7 +79,7 @@ if (coord_var %in% s) {
 }
 
 # extract ID column name
-if (missing(fid)) {
+if (fid == 'default') {
   id_col <- names(p[1])[1]
 } else {
   id_col <- fid

--- a/depth_to_bedrock/depth_to_bedrock.sh
+++ b/depth_to_bedrock/depth_to_bedrock.sh
@@ -41,12 +41,12 @@
 # Usage Functions
 # ===============
 short_usage() {
-  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
+  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-F STR] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
 }
 
 
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n depth-to-bedrock -o i:o:v:r:s:e:l:n:f:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
+parsedArguments=$(getopt -a -n depth-to-bedrock -o i:o:v:r:s:e:l:n:f:F:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,fid:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
 validArguments=$?
 if [ "$validArguments" != "0" ]; then
   short_usage;
@@ -73,6 +73,7 @@ do
     -l | --lat-lims)      latLims="$2"         ; shift 2 ;; # required - could be redundant
     -n | --lon-lims)      lonLims="$2"         ; shift 2 ;; # required - could be redundant
     -f | --shape-file)    shapefile="$2"       ; shift 2 ;; # required - could be redundant
+    -F | --fid)           fid="$2"             ; shift 2 ;; # required
     -t | --print-geotiff) printGeotiff="$2"    ; shift 2 ;; # required
     -a | --stat)	  stats="$2"	       ; shift 2 ;; # optional
     -u | --include-na)	  includeNA="$2"       ; shift 2 ;; # required
@@ -276,7 +277,8 @@ if [[ -n "$shapefile" ]] && [[ -n $stats ]]; then
 	    "$outputDir/${prefix}stats_${var}.csv" \
 	    "$stats" \
 	    "$includeNA" \
-	    "$quantiles" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
+	    "$quantiles" \
+	    "$fid" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
   done
 fi
 

--- a/extract-gis.sh
+++ b/extract-gis.sh
@@ -284,7 +284,7 @@ if [[ "$stats" == *"quantile"* ]] && [[ -z $quantiles ]]; then
 fi
 
 # if account is not provided, use `rpp-kshook` as default
-if [[ -z $account ]]; then
+if [[ -z $account ]] && [[ -n $submitJob ]]; then
   account="rpp-kshook"
   if [[ -z $parsable ]]; then
     echo "$(basename $0): WARNING! --account not provided, using \`rpp-kshook\` by default."
@@ -301,11 +301,10 @@ if [[ -z $libPath ]]; then
 fi
 
 # if `--fid` is not provided
-if [[ -z $fid ]]; then
-  if [[ -z $parsable ]] && [[ -n $stats  ]]; then
-    echo "$(basename $0): WARNING! --fid not provided, using the first"
-    echo "                column of `${shapefile}` to report statistics"
-  fi
+if [[ -z $fid ]] && [[ -z $parsable ]] && [[ -n $stats  ]]; then
+  fid='default'
+  echo "$(basename $0): WARNING! --fid not provided, using the first"
+  echo "                column of the input ESRI Shapefile to report statistics"
 fi
 
 

--- a/gsde/gsde.sh
+++ b/gsde/gsde.sh
@@ -41,12 +41,12 @@
 # Usage Functions
 # ===============
 short_usage() {
-  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
+  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-F STR] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
 }
 
 
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n gsde -o i:o:v:r:s:e:l:n:f:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:lib-path: -- "$@")
+parsedArguments=$(getopt -a -n gsde -o i:o:v:r:s:e:l:n:f:F:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,fid:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:lib-path: -- "$@")
 validArguments=$?
 if [ "$validArguments" != "0" ]; then
   short_usage;
@@ -73,6 +73,7 @@ do
     -l | --lat-lims)      latLims="$2"         ; shift 2 ;; # required - could be redundant
     -n | --lon-lims)      lonLims="$2"         ; shift 2 ;; # required - could be redundant
     -f | --shape-file)    shapefile="$2"       ; shift 2 ;; # required - could be redundant
+    -F | --fid)           fid="$2"             ; shift 2 ;; # required
     -t | --print-geotiff) printGeotiff="$2"    ; shift 2 ;; # required
     -a | --stat)	  stats="$2"	       ; shift 2 ;; # optional
     -u | --include-na)	  includeNA="$2"       ; shift 2 ;; # required
@@ -289,7 +290,8 @@ if [[ -n "$shapefile" ]] && [[ -n $stats ]]; then
 	    "$outputDir/${prefix}stats_${var}.csv" \
 	    "$stats" \
 	    "$includeNA" \
-	    "$quantiles" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
+	    "$quantiles" \
+	    "$fid" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
   done
 fi
 

--- a/landsat/landsat.sh
+++ b/landsat/landsat.sh
@@ -411,7 +411,7 @@ for f in "${files[@]}"; do
 done
 
 # extracting the .zip files
-echo "$(logDate)$(basename $0): Extracting Landsat .zip files..."
+echo "$(logDate)$(basename $0): Extracting Landsat .zip files under ${cache}"
 for zipFile in "${filesComplete[@]}"; do
   # IMPORTANT: 7z is needed as a dependency
   7z e -y -bsp0 -bso0 "${geotiffDir}/${zipFile}"* -o${cache} *.tif -r

--- a/landsat/landsat.sh
+++ b/landsat/landsat.sh
@@ -41,12 +41,12 @@
 # Usage Functions
 # ===============
 short_usage() {
-  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
+  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-F STR] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
 }
 
 
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n landsat -o i:o:v:r:s:e:l:n:f:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
+parsedArguments=$(getopt -a -n landsat -o i:o:v:r:s:e:l:n:f:F:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,fid:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
 validArguments=$?
 if [ "$validArguments" != "0" ]; then
   short_usage;
@@ -73,6 +73,7 @@ do
     -l | --lat-lims)      latLims="$2"         ; shift 2 ;; # required - could be redundant
     -n | --lon-lims)      lonLims="$2"         ; shift 2 ;; # required - could be redundant
     -f | --shape-file)    shapefile="$2"       ; shift 2 ;; # required - could be redundant
+    -F | --fid)           fid="$2"             ; shift 2 ;; # optional
     -t | --print-geotiff) printGeotiff="$2"    ; shift 2 ;; # required
     -a | --stat)	  stats="$2"	       ; shift 2 ;; # optional
     -u | --include-na)	  includeNA="$2"       ; shift 2 ;; # required
@@ -474,7 +475,8 @@ if [[ -n "$shapefile" ]] && [[ -n $stats ]]; then
 	    "$outputDir/${prefix}stats_${fileName[0]}.csv" \
 	    "$stats" \
 	    "$includeNA" \
-	    "$quantiles" >> "${outputDir}/${prefix}stats_${fileName[0]}.log" 2>&1; 
+	    "$quantiles" \
+	    "$fid" >> "${outputDir}/${prefix}stats_${fileName[0]}.log" 2>&1; 
     wait;
   done
 fi

--- a/merit_hydro/merit_hydro.sh
+++ b/merit_hydro/merit_hydro.sh
@@ -43,12 +43,12 @@
 # Usage Functions
 # ===============
 short_usage() {
-  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
+  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-F STR] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR]"
 }
 
 
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n merit_hydro -o i:o:v:r:s:e:l:n:f:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
+parsedArguments=$(getopt -a -n merit_hydro -o i:o:v:r:s:e:l:n:f:F:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,fid:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
 validArguments=$?
 if [ "$validArguments" != "0" ]; then
   short_usage;
@@ -75,6 +75,7 @@ do
     -l | --lat-lims)      latLims="$2"         ; shift 2 ;; # required - could be redundant
     -n | --lon-lims)      lonLims="$2"         ; shift 2 ;; # required - could be redundant
     -f | --shape-file)    shapefile="$2"       ; shift 2 ;; # required - could be redundant
+    -F | --fid)           fid="$2"             ; shift 2 ;; # optional
     -t | --print-geotiff) printGeotiff="$2"    ; shift 2 ;; # required
     -a | --stat)	  stats="$2"	       ; shift 2 ;; # optional
     -u | --include-na)	  includeNA="$2"       ; shift 2 ;; # required
@@ -379,7 +380,8 @@ if [[ -n "$shapefile" ]] && [[ -n $stats ]]; then
 	    "$outputDir/${prefix}stats_${var}.csv" \
 	    "$stats" \
 	    "$includeNA" \
-	    "$quantiles" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
+	    "$quantiles" \
+	    "$fid" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
   done
 fi
 

--- a/modis/modis.sh
+++ b/modis/modis.sh
@@ -41,12 +41,12 @@
 # Usage Functions
 # ===============
 short_usage() {
-  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
+  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-F STR] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
 }
 
 
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n modis -o i:o:v:r:s:e:l:n:f:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:lib-path: -- "$@")
+parsedArguments=$(getopt -a -n modis -o i:o:v:r:s:e:l:n:f:F:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,fid:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:lib-path: -- "$@")
 validArguments=$?
 if [ "$validArguments" != "0" ]; then
   short_usage;
@@ -73,6 +73,7 @@ do
     -l | --lat-lims)      latLims="$2"         ; shift 2 ;; # required - could be redundant
     -n | --lon-lims)      lonLims="$2"         ; shift 2 ;; # required - could be redundant
     -f | --shape-file)    shapefile="$2"       ; shift 2 ;; # required - could be redundant
+    -F | --fid)           fid="$2"             ; shift 2 ;; # optional
     -t | --print-geotiff) printGeotiff="$2"    ; shift 2 ;; # required
     -a | --stat)	  stats="$2"	       ; shift 2 ;; # optional
     -u | --include-na)    includeNA="$2"       ; shift 2 ;; # required
@@ -317,7 +318,8 @@ if [[ -n "$shapefile" ]] && [[ -n $stats ]]; then
 	      "$outputDir/${var}/${prefix}stats_${var}_${yr}.csv" \
 	      "$stats" \
 	      "$includeNA" \
-	      "$quantiles" >> "${outputDir}/${var}/${prefix}stats_${var}_${yr}.log" 2>&1;
+	      "$quantiles" \
+	      "$fid" >> "${outputDir}/${var}/${prefix}stats_${var}_${yr}.log" 2>&1;
     done
   done
 fi

--- a/soil_class/soil_class.sh
+++ b/soil_class/soil_class.sh
@@ -41,12 +41,12 @@
 # Usage Functions
 # ===============
 short_usage() {
-  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-t BOOL] [-a stat1[,stat2,[...]] [-q q1[,q2[...]]]] [-p STR] "
+  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-F STR] [-t BOOL] [-a stat1[,stat2,[...]] [-q q1[,q2[...]]]] [-p STR] "
 }
 
 
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n soil-class -o i:o:v:r:s:e:l:n:f:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
+parsedArguments=$(getopt -a -n soil-class -o i:o:v:r:s:e:l:n:f:F:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,fid:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
 validArguments=$?
 if [ "$validArguments" != "0" ]; then
   short_usage;
@@ -73,6 +73,7 @@ do
     -l | --lat-lims)      latLims="$2"         ; shift 2 ;; # required - could be redundant
     -n | --lon-lims)      lonLims="$2"         ; shift 2 ;; # required - could be redundant
     -f | --shape-file)    shapefile="$2"       ; shift 2 ;; # required - could be redundant
+    -F | --fid)           fid="$2"             ; shift 2 ;; # optional
     -t | --print-geotiff) printGeotiff="$2"    ; shift 2 ;; # required
     -a | --stat)	  stats="$2"	       ; shift 2 ;; # optional
     -u | --include-na)    includeNA="$2"       ; shift 2 ;; # required
@@ -276,7 +277,8 @@ if [[ -n "$shapefile" ]] && [[ -n $stats ]]; then
 	    "$outputDir/${prefix}stats_${var}.csv" \
 	    "$stats" \
 	    "$includeNA" \
-	    "$quantiles" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
+	    "$quantiles" \
+	    "$fid" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
   done
 fi
 

--- a/soil_grids/soil_grids_v1.sh
+++ b/soil_grids/soil_grids_v1.sh
@@ -41,12 +41,12 @@
 # Usage Functions
 # ===============
 short_usage() {
-  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
+  echo "usage: $(basename $0) -cio DIR -v var1[,var2[...]] [-r INT] [-se DATE] [-ln REAL,REAL] [-f PATH] [-F STR] [-t BOOL] [-a stat1[,stat2,[...]] [-u BOOL] [-q q1[,q2[...]]]] [-p STR] "
 }
 
 
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n soil-grids-v1 -o i:o:v:r:s:e:l:n:f:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
+parsedArguments=$(getopt -a -n soil-grids-v1 -o i:o:v:r:s:e:l:n:f:F:t:a:u:q:p:c:L: --long dataset-dir:,output-dir:,variable:,crs:,start-date:,end-date:,lat-lims:,lon-lims:,shape-file:,fid:,print-geotiff:,stat:,include-na:,quantile:,prefix:,cache:,lib-path: -- "$@")
 validArguments=$?
 if [ "$validArguments" != "0" ]; then
   short_usage;
@@ -73,6 +73,7 @@ do
     -l | --lat-lims)      latLims="$2"         ; shift 2 ;; # required - could be redundant
     -n | --lon-lims)      lonLims="$2"         ; shift 2 ;; # required - could be redundant
     -f | --shape-file)    shapefile="$2"       ; shift 2 ;; # required - could be redundant
+    -F | --fid)           fid="$2"             ; shift 2 ;; # optional
     -t | --print-geotiff) printGeotiff="$2"    ; shift 2 ;; # required
     -a | --stat)	  stats="$2"	       ; shift 2 ;; # optional
     -u | --include-na)    includeNA="$2"       ; shift 2 ;; # required
@@ -275,7 +276,8 @@ if [[ -n "$shapefile" ]] && [[ -n $stats ]]; then
 	    "$outputDir/${prefix}stats_${var}.csv" \
 	    "$stats" \
 	    "$includeNA" \
-	    "$quantiles" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
+	    "$quantiles" \
+	    "$fid" >> "${outputDir}/${prefix}stats_${var}.log" 2>&1;
   done
 fi
 


### PR DESCRIPTION
Since many geofabrics are out there, and not necessarily the ID that the user is interested in is the first column (although kept as default for backward compatibility), the --fid=STR option provides a way for the user to extract necessary statistics for that column of interest.

Resolving #35 